### PR TITLE
Create a new pull request by comparing changes

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -52,14 +52,18 @@ module.exports = function httpAdapter(config) {
     };
     var data = config.data;
     var headers = config.headers;
+    var headerNames = {};
+
+    Object.keys(headers).forEach(function storeLowerName(name) {
+      headerNames[name.toLowerCase()] = name;
+    });
 
     // Set User-Agent (required by some servers)
     // See https://github.com/axios/axios/issues/69
-    if ('User-Agent' in headers || 'user-agent' in headers) {
+    if ('user-agent' in headerNames) {
       // User-Agent is specified; handle case where no UA header is desired
-      if (!headers['User-Agent'] && !headers['user-agent']) {
-        delete headers['User-Agent'];
-        delete headers['user-agent'];
+      if (!headers[headerNames['user-agent']]) {
+        delete headers[headerNames['user-agent']];
       }
       // Otherwise, use specified value
     } else {
@@ -82,7 +86,9 @@ module.exports = function httpAdapter(config) {
       }
 
       // Add Content-Length header if data exists
-      headers['Content-Length'] = data.length;
+      if (!headerNames['content-length']) {
+        headers['Content-Length'] = data.length;
+      }
     }
 
     // HTTP basic authentication
@@ -105,8 +111,8 @@ module.exports = function httpAdapter(config) {
       auth = urlUsername + ':' + urlPassword;
     }
 
-    if (auth) {
-      delete headers.Authorization;
+    if (auth && headerNames.authorization) {
+      delete headers[headerNames.authorization];
     }
 
     var isHttpsRequest = isHttps.test(protocol);


### PR DESCRIPTION
* Caseless header comparing in HTTP adapter.

It was adding User-Agent and removing Authorization, but only when
existing headers had the exact right casing. Node uses caseless logic
when managing headers.

This was causing some requests to have `User-Agent` appended to the
headers object and overriding provided agent strings.

Also included is an update to not override the `Content-Length` if it
was already defined in the options. It can be desirable to manually
specify a content length that does not match the data on hand.
Especially for testing.

* Fix eslint error

* fixup: update state UA logic

Play nice with https://github.com/axios/axios/pull/3703

Co-authored-by: Jay <jasonsaayman@gmail.com>

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow the instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/axios/axios/blob/master/CONTRIBUTING.md).

**⚠️👆 Delete the instructions before submitting the pull request 👆⚠️**

Describe your pull request here.
